### PR TITLE
feat: add typescript support

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -19,6 +19,7 @@ export const parse: Parser<Root | Document> = (
   const doc = new Document();
   const ast = babelParse(source.toString(), {
     sourceType: 'unambiguous',
+    plugins: ['typescript'],
     ranges: true
   });
   const extractedStyles = new Set<TaggedTemplateExpression>();
@@ -41,7 +42,6 @@ export const parse: Parser<Root | Document> = (
     }
 
     const startIndex = node.quasi.range[0] + 1;
-    // const endIndex = node.quasi.range[1] - 1;
 
     const styleText = node.quasi.quasis
       .map((template) => template.value.raw)

--- a/src/test/.eslintrc.json
+++ b/src/test/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "require-jsdoc": "off",
+    "@typescript-eslint/no-non-null-assertion": "off"
+  }
+}

--- a/src/test/locationCorrection_test.ts
+++ b/src/test/locationCorrection_test.ts
@@ -1,53 +1,10 @@
-import {Document, Root, Rule, Declaration, Node} from 'postcss';
+import {Root, Rule, Declaration} from 'postcss';
 import {assert} from 'chai';
-import {parse} from '../parse.js';
-
-const createTestAst = (source: string): {ast: Document; source: string} => {
-  const ast = parse(source) as Document;
-
-  return {ast, source};
-};
-
-const getSourceForLoc = (source: string, node: Node): string => {
-  const loc = node.source;
-
-  if (!loc || !loc.start || !loc.end) {
-    return '';
-  }
-
-  const lines = source.split(/\r\n|\n/);
-  const result: string[] = [];
-  const startLineIndex = loc.start.line - 1;
-  const endLineIndex = loc.end.line - 1;
-
-  for (let i = startLineIndex; i < loc.end.line; i++) {
-    const line = lines[i];
-    if (line) {
-      let offsetStart = 0;
-      let offsetEnd = line.length;
-
-      if (i === startLineIndex) {
-        offsetStart = loc.start.column - 1;
-      }
-
-      if (i === endLineIndex) {
-        offsetEnd = loc.end.column;
-      }
-
-      result.push(line.substring(offsetStart, offsetEnd));
-    }
-  }
-
-  return result.join('\n');
-};
-
-const getSourceForRange = (source: string, node: Node): string => {
-  if (!node.source || !node.source.start || !node.source.end) {
-    return '';
-  }
-
-  return source.substring(node.source.start.offset, node.source.end.offset + 1);
-};
+import {
+  createTestAst,
+  getSourceForNodeByRange,
+  getSourceForNodeByLoc
+} from './util.js';
 
 describe('locationCorrection', () => {
   it('should translate basic CSS positions', () => {
@@ -60,10 +17,16 @@ describe('locationCorrection', () => {
     const colour = rule.nodes[0] as Declaration;
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
-    assert.equal(getSourceForLoc(source, rule), '.foo { color: hotpink; }');
-    assert.equal(getSourceForLoc(source, colour), 'color: hotpink;');
-    assert.equal(getSourceForRange(source, rule), '.foo { color: hotpink; }');
-    assert.equal(getSourceForRange(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      '.foo { color: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      '.foo { color: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
 
   it('should account for single-line expressions', () => {
@@ -77,15 +40,15 @@ describe('locationCorrection', () => {
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
     assert.equal(
-      getSourceForLoc(source, rule),
+      getSourceForNodeByLoc(source, rule),
       '.foo { ${expr}color: hotpink; }'
     );
-    assert.equal(getSourceForLoc(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
     assert.equal(
-      getSourceForRange(source, rule),
+      getSourceForNodeByRange(source, rule),
       '.foo { ${expr}color: hotpink; }'
     );
-    assert.equal(getSourceForRange(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
 
   it('should account for multiple single-line expressions', () => {
@@ -99,15 +62,21 @@ describe('locationCorrection', () => {
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
     assert.equal(
-      getSourceForLoc(source, rule),
+      getSourceForNodeByLoc(source, rule),
       '.foo { ${expr}color: ${expr2}hotpink; }'
     );
-    assert.equal(getSourceForLoc(source, colour), 'color: ${expr2}hotpink;');
     assert.equal(
-      getSourceForRange(source, rule),
+      getSourceForNodeByLoc(source, colour),
+      'color: ${expr2}hotpink;'
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
       '.foo { ${expr}color: ${expr2}hotpink; }'
     );
-    assert.equal(getSourceForRange(source, colour), 'color: ${expr2}hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, colour),
+      'color: ${expr2}hotpink;'
+    );
   });
 
   it('should account for multi-line expressions', () => {
@@ -123,19 +92,19 @@ describe('locationCorrection', () => {
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
     assert.equal(
-      getSourceForLoc(source, rule),
+      getSourceForNodeByLoc(source, rule),
       `.foo { $\{
           expr
         }color: hotpink; }`
     );
-    assert.equal(getSourceForLoc(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
     assert.equal(
-      getSourceForRange(source, rule),
+      getSourceForNodeByRange(source, rule),
       `.foo { $\{
           expr
         }color: hotpink; }`
     );
-    assert.equal(getSourceForRange(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
 
   it('should account for multiple mixed-size expressions', () => {
@@ -151,18 +120,41 @@ describe('locationCorrection', () => {
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
     assert.equal(
-      getSourceForLoc(source, rule),
+      getSourceForNodeByLoc(source, rule),
       `.foo { $\{
           expr
         } $\{expr2}color: hotpink; }`
     );
-    assert.equal(getSourceForLoc(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
     assert.equal(
-      getSourceForRange(source, rule),
+      getSourceForNodeByRange(source, rule),
       `.foo { $\{
           expr
         } $\{expr2}color: hotpink; }`
     );
-    assert.equal(getSourceForRange(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+  });
+
+  it('should account for code before', () => {
+    const {source, ast} = createTestAst(`
+      const foo = bar + baz;
+      css\`
+        .foo { color: hotpink; }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(colour.type, 'decl');
+    assert.equal(rule.type, 'rule');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      '.foo { color: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      '.foo { color: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
 });

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -1,0 +1,62 @@
+import {Root, Rule, Declaration} from 'postcss';
+import {assert} from 'chai';
+import {createTestAst} from './util.js';
+
+describe('parse', () => {
+  it('should parse basic CSS', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { color: hotpink; }
+      \`;
+    `);
+    const root = ast.nodes[0] as Root;
+    const rule = root.nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(ast.type, 'document');
+    assert.equal(root.type, 'root');
+    assert.equal(rule.type, 'rule');
+    assert.equal(colour.type, 'decl');
+    assert.equal(root.raws.codeBefore, '\n      css`');
+    assert.equal(root.parent, ast);
+    assert.equal(root.raws.codeAfter, '`;\n    ');
+    assert.deepEqual(ast.source!.start, {
+      line: 1,
+      column: 1,
+      offset: 0
+    });
+    assert.equal(ast.source!.input.css, source);
+  });
+
+  it('should parse modern JS', () => {
+    const {ast} = createTestAst(`
+      const someObj = {a: {b: 2}};
+      const someValue = someObj?.a?.b ?? 3;
+      css\`
+        .foo { color: hotpink; }
+      \`;
+    `);
+    const root = ast.nodes[0] as Root;
+    const rule = root.nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(ast.type, 'document');
+    assert.equal(root.type, 'root');
+    assert.equal(rule.type, 'rule');
+    assert.equal(colour.type, 'decl');
+  });
+
+  it('should parse typescript', () => {
+    const {ast} = createTestAst(`
+      function doStuff(x: number, y: number): void {}
+      css\`
+        .foo { color: hotpink; }
+      \`;
+    `);
+    const root = ast.nodes[0] as Root;
+    const rule = root.nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(ast.type, 'document');
+    assert.equal(root.type, 'root');
+    assert.equal(rule.type, 'rule');
+    assert.equal(colour.type, 'decl');
+  });
+});

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -1,0 +1,49 @@
+import {Document, Node} from 'postcss';
+import {parse} from '../parse.js';
+
+export function createTestAst(source: string): {ast: Document; source: string} {
+  const ast = parse(source) as Document;
+
+  return {ast, source};
+}
+
+export function getSourceForNodeByLoc(source: string, node: Node): string {
+  const loc = node.source;
+
+  if (!loc || !loc.start || !loc.end) {
+    return '';
+  }
+
+  const lines = source.split(/\r\n|\n/);
+  const result: string[] = [];
+  const startLineIndex = loc.start.line - 1;
+  const endLineIndex = loc.end.line - 1;
+
+  for (let i = startLineIndex; i < loc.end.line; i++) {
+    const line = lines[i];
+    if (line) {
+      let offsetStart = 0;
+      let offsetEnd = line.length;
+
+      if (i === startLineIndex) {
+        offsetStart = loc.start.column - 1;
+      }
+
+      if (i === endLineIndex) {
+        offsetEnd = loc.end.column;
+      }
+
+      result.push(line.substring(offsetStart, offsetEnd));
+    }
+  }
+
+  return result.join('\n');
+}
+
+export function getSourceForNodeByRange(source: string, node: Node): string {
+  if (!node.source || !node.source.start || !node.source.end) {
+    return '';
+  }
+
+  return source.substring(node.source.start.offset, node.source.end.offset + 1);
+}


### PR DESCRIPTION
the babel parser already supports parsing typescript, and regular JS _is_ typescript.

so i think we can get away with just permanently turning it on like this, regardless of if we're parsing js or ts.