### PR TITLE
feat: implement syntax stringifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2995,9 +2995,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.0.tgz",
-      "integrity": "sha512-BRMNx3Wy7UI89jN8H4ZVS5lQMPM2OSMkOkvDCSjwXa7PWTs24k7Lm55NXLbMbs070LvraXaxN5l1npSOS6wMVw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.1.tgz",
+      "integrity": "sha512-WqLs/TTzXdG+/A4ZOOK9WDZiikrRaiA+eoEb/jz2DT9KUhMNHgP7yKPO8vwi62ZCsb703Gwb7BMZwDzI54Y2Ag==",
       "dev": true,
       "dependencies": {
         "nanoid": "^3.1.30",
@@ -3022,9 +3022,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -5859,9 +5859,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.0.tgz",
-      "integrity": "sha512-BRMNx3Wy7UI89jN8H4ZVS5lQMPM2OSMkOkvDCSjwXa7PWTs24k7Lm55NXLbMbs070LvraXaxN5l1npSOS6wMVw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.1.tgz",
+      "integrity": "sha512-WqLs/TTzXdG+/A4ZOOK9WDZiikrRaiA+eoEb/jz2DT9KUhMNHgP7yKPO8vwi62ZCsb703Gwb7BMZwDzI54Y2Ag==",
       "dev": true,
       "requires": {
         "nanoid": "^3.1.30",
@@ -5876,9 +5876,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
       "dev": true
     },
     "process-on-spawn": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,0 @@
-export const PLACEHOLDER = '/* 808 */';

--- a/src/locationCorrection.ts
+++ b/src/locationCorrection.ts
@@ -1,6 +1,6 @@
 import {Root, Position, ChildNode} from 'postcss';
 import {TaggedTemplateExpression} from '@babel/types';
-import {PLACEHOLDER} from './constants.js';
+import {createPlaceholder} from './util.js';
 
 const correctLocation = (
   node: TaggedTemplateExpression,
@@ -34,8 +34,9 @@ const correctLocation = (
       nextQuasi.range &&
       previousQuasi.range[1] < newOffset
     ) {
+      const placeholderSize = createPlaceholder(i).length;
       const exprSize =
-        nextQuasi.range[0] - previousQuasi.range[1] - PLACEHOLDER.length;
+        nextQuasi.range[0] - previousQuasi.range[1] - placeholderSize;
       const exprStartLine = previousQuasi.loc.end.line;
       const exprEndLine = nextQuasi.loc.start.line;
       newOffset += exprSize;
@@ -49,7 +50,7 @@ const correctLocation = (
           columnOffset =
             nextQuasi.loc.start.column -
             previousQuasi.loc.end.column -
-            PLACEHOLDER.length;
+            placeholderSize;
         }
       } else {
         columnOffset += exprSize;

--- a/src/locationCorrection.ts
+++ b/src/locationCorrection.ts
@@ -1,4 +1,4 @@
-import {Root, Position, ChildNode} from 'postcss';
+import {Root, Position, Document, ChildNode} from 'postcss';
 import {TaggedTemplateExpression} from '@babel/types';
 import {createPlaceholder} from './util.js';
 
@@ -76,8 +76,8 @@ const correctLocation = (
  */
 export function locationCorrectionWalker(
   expr: TaggedTemplateExpression
-): (node: ChildNode | Root) => void {
-  return (node: ChildNode | Root): void => {
+): (node: Document | Root | ChildNode) => void {
+  return (node: Document | Root | ChildNode): void => {
     if (node.source?.start) {
       node.source.start = correctLocation(expr, node.source.start);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import {Syntax} from 'postcss';
 import {parse} from './parse.js';
+import {stringify} from './stringify.js';
 
 const syntax: Syntax = {
-  parse
+  parse,
+  stringify
 };
 
 export {syntax};

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -3,7 +3,7 @@ import postcssParse from 'postcss/lib/parse';
 import {parse as babelParse} from '@babel/parser';
 import {default as traverse, NodePath} from '@babel/traverse';
 import {TaggedTemplateExpression} from '@babel/types';
-import {PLACEHOLDER} from './constants.js';
+import {createPlaceholder} from './util.js';
 import {locationCorrectionWalker} from './locationCorrection.js';
 
 /**
@@ -17,7 +17,8 @@ export const parse: Parser<Root | Document> = (
   opts?: Pick<ProcessOptions, 'map' | 'from'>
 ): Root | Document => {
   const doc = new Document();
-  const ast = babelParse(source.toString(), {
+  const sourceAsString = source.toString();
+  const ast = babelParse(sourceAsString, {
     sourceType: 'unambiguous',
     plugins: ['typescript'],
     ranges: true
@@ -43,33 +44,53 @@ export const parse: Parser<Root | Document> = (
 
     const startIndex = node.quasi.range[0] + 1;
 
-    const styleText = node.quasi.quasis
-      .map((template) => template.value.raw)
-      .join(PLACEHOLDER);
+    const expressionStrings: string[] = [];
+    let styleText = '';
+
+    for (let i = 0; i < node.quasi.quasis.length; i++) {
+      const template = node.quasi.quasis[i];
+      const expr = node.quasi.expressions[i];
+      const nextTemplate = node.quasi.quasis[i + 1];
+
+      if (template) {
+        styleText += template.value.raw;
+
+        if (expr && nextTemplate && nextTemplate.range && template.range) {
+          const exprText = sourceAsString.slice(
+            template.range[1],
+            nextTemplate.range[0]
+          );
+          styleText += createPlaceholder(i);
+          expressionStrings.push(exprText);
+        }
+      }
+    }
+
     const root = postcssParse(styleText, {
       ...opts,
       map: false
     });
 
-    root.raws.codeBefore = source.toString().slice(currentOffset, startIndex);
+    root.raws['templateExpressions'] = expressionStrings;
+    root.raws.codeBefore = sourceAsString.slice(currentOffset, startIndex);
     root.parent = doc;
     const walker = locationCorrectionWalker(node);
     walker(root);
     root.walk(walker);
     doc.nodes.push(root);
 
-    currentOffset = startIndex + styleText.length;
+    currentOffset = node.quasi.range[1] - 1;
   }
 
   if (doc.nodes.length > 0) {
     const last = doc.nodes[doc.nodes.length - 1];
     if (last) {
-      last.raws.codeAfter = source.toString().slice(currentOffset);
+      last.raws.codeAfter = sourceAsString.slice(currentOffset);
     }
   }
 
   doc.source = {
-    input: new Input(source.toString(), opts),
+    input: new Input(sourceAsString, opts),
     start: {
       line: 1,
       column: 1,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -69,7 +69,7 @@ export const parse: Parser<Root | Document> = (
     const root = postcssParse(styleText, {
       ...opts,
       map: false
-    });
+    }) as Root;
 
     root.raws['templateExpressions'] = expressionStrings;
     root.raws.codeBefore = sourceAsString.slice(currentOffset, startIndex);

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,0 +1,52 @@
+import {
+  Stringifier as StringifierFn,
+  Comment,
+  Root,
+  AnyNode,
+  Builder
+} from 'postcss';
+import Stringifier from 'postcss/lib/stringifier';
+
+const placeholderPattern = /^POSTCSS_LIT:\d+$/;
+
+/**
+ * Stringifies PostCSS nodes while taking interpolated expressions
+ * into account.
+ */
+class LitStringifier extends Stringifier {
+  /** @inheritdoc */
+  public override comment(node: Comment): void {
+    if (placeholderPattern.test(node.text)) {
+      const [, expressionIndexString] = node.text.split(':');
+      const expressionIndex = Number(expressionIndexString);
+      const root = node.root();
+      const expressionStrings = root.raws['templateExpressions'];
+
+      if (expressionStrings && !Number.isNaN(expressionIndex)) {
+        const expression = expressionStrings[expressionIndex];
+
+        if (expression) {
+          this.builder(expression, node);
+          return;
+        }
+      }
+    }
+
+    super.comment(node);
+  }
+
+  /** @inheritdoc */
+  public override root(node: Root): void {
+    this.builder(node.raws.codeBefore ?? '', node, 'start');
+    super.root(node);
+    this.builder(node.raws.codeAfter ?? '', node, 'end');
+  }
+}
+
+export const stringify: StringifierFn = (
+  node: AnyNode,
+  builder: Builder
+): void => {
+  const str = new LitStringifier(builder);
+  str.stringify(node);
+};

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -1,4 +1,4 @@
-import {Root, Rule, Declaration} from 'postcss';
+import {Root, Rule, Declaration, Comment} from 'postcss';
 import {assert} from 'chai';
 import {createTestAst} from './util.js';
 
@@ -58,5 +58,52 @@ describe('parse', () => {
     assert.equal(root.type, 'root');
     assert.equal(rule.type, 'rule');
     assert.equal(colour.type, 'decl');
+  });
+
+  it('should parse multiple stylesheets', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { color: hotpink; }
+      \`;
+
+      css\`.bar: { background: lime; }\`;
+    `);
+    assert.equal(ast.nodes.length, 2);
+    const root1 = ast.nodes[0] as Root;
+    const root2 = ast.nodes[1] as Root;
+
+    assert.equal(root1.type, 'root');
+    assert.equal(root1.raws.codeBefore, '\n      css`');
+    assert.equal(root1.raws.codeAfter, undefined);
+    assert.equal(root1.parent, ast);
+    assert.equal(root2.type, 'root');
+    assert.equal(root2.raws.codeBefore, '`;\n\n      css`');
+    assert.equal(root2.raws.codeAfter, '`;\n    ');
+    assert.equal(root2.parent, ast);
+
+    assert.deepEqual(ast.source!.start, {
+      line: 1,
+      column: 1,
+      offset: 0
+    });
+    assert.equal(ast.source!.input.css, source);
+  });
+
+  it('should parse CSS containing an expression', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { $\{expr}color: hotpink; }
+      \`;
+    `);
+    const root = ast.nodes[0] as Root;
+    const rule = root.nodes[0] as Rule;
+    const placeholder = rule.nodes[0] as Comment;
+    const colour = rule.nodes[1] as Declaration;
+    assert.equal(ast.type, 'document');
+    assert.equal(root.type, 'root');
+    assert.equal(rule.type, 'rule');
+    assert.equal(placeholder.type, 'comment');
+    assert.equal(colour.type, 'decl');
+    assert.equal(ast.source!.input.css, source);
   });
 });

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -106,4 +106,32 @@ describe('parse', () => {
     assert.equal(colour.type, 'decl');
     assert.equal(ast.source!.input.css, source);
   });
+
+  it('should parse JS without any CSS', () => {
+    const {source, ast} = createTestAst(`
+      const foo = 'bar';
+    `);
+    assert.equal(ast.type, 'document');
+    assert.equal(ast.nodes.length, 0);
+    assert.deepEqual(ast.source!.start, {
+      line: 1,
+      column: 1,
+      offset: 0
+    });
+    assert.equal(ast.source!.input.css, source);
+  });
+
+  it('should ignore non-css templates', () => {
+    const {source, ast} = createTestAst(`
+      html\`<div></div>\`;
+    `);
+    assert.equal(ast.type, 'document');
+    assert.equal(ast.nodes.length, 0);
+    assert.deepEqual(ast.source!.start, {
+      line: 1,
+      column: 1,
+      offset: 0
+    });
+    assert.equal(ast.source!.input.css, source);
+  });
 });

--- a/src/test/postcss_test.ts
+++ b/src/test/postcss_test.ts
@@ -1,0 +1,31 @@
+import {Rule, Declaration, Document, default as postcss} from 'postcss';
+import {assert} from 'chai';
+import {syntax} from '../main.js';
+
+describe('parse', () => {
+  it('should parse basic CSS', async () => {
+    const source = `
+      css\`
+        .foo { color: hotpink; }
+      \`;
+    `;
+    const result = await postcss().process(source, {syntax, from: 'foo.js'});
+    const ast = result.root as unknown as Document;
+    const root = ast.nodes[0]!;
+    const rule = root.nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(ast.type, 'document');
+    assert.equal(root.type, 'root');
+    assert.equal(rule.type, 'rule');
+    assert.equal(colour.type, 'decl');
+    assert.equal(root.raws.codeBefore, '\n      css`');
+    assert.equal(root.parent, ast);
+    assert.equal(root.raws.codeAfter, '`;\n    ');
+    assert.deepEqual(ast.source!.start, {
+      line: 1,
+      column: 1,
+      offset: 0
+    });
+    assert.equal(ast.source!.input.css, source);
+  });
+});

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -118,4 +118,37 @@ describe('stringify', () => {
     `
     );
   });
+
+  it('should ignore non-placeholder comments', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { /*BOOP*/color: hotpink; }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
+  it('should handle deleted individual expression state', () => {
+    const {ast} = createTestAst(`
+      css\`
+        .foo { $\{expr}color: hotpink; }
+      \`;
+    `);
+
+    const root = ast.nodes[0]!;
+    root.raws['templateExpressions'] = [];
+    const output = ast.toString(syntax);
+
+    assert.equal(
+      output,
+      `
+      css\`
+        .foo { /*POSTCSS_LIT:0*/color: hotpink; }
+      \`;
+    `
+    );
+  });
 });

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -1,0 +1,121 @@
+import {assert} from 'chai';
+import {createTestAst} from './util.js';
+import {syntax} from '../main.js';
+
+describe('stringify', () => {
+  it('should stringify basic CSS', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { color: hotpink; }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
+  it('should stringify single-line expressions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { $\{expr}color: hotpink; }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
+  it('should stringify multi-line expressions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { $\{
+          expr
+        }color: hotpink; }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
+  it('should stringify multiple expressions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { $\{expr}color: hotpink; }
+        .bar { $\{expr2}color: lime; }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
+  it('should stringify multiple same-named expressions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { $\{expr}color: hotpink; }
+        .bar { $\{expr}color: lime; }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
+  it('should stringify multiple multi-line expressions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { $\{
+          expr }$\{
+          expr2
+        }color: hotpink; }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
+  it('should stringify multiple stylesheets', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { color: hotpink; }
+      \`;
+
+      const somethingInTheMiddle = 808;
+
+      css\`.foo { color: lime; }\`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
+  it('should handle deleted (by another plugin) expression state', () => {
+    const {ast} = createTestAst(`
+      css\`
+        .foo { $\{expr}color: hotpink; }
+      \`;
+    `);
+
+    const root = ast.nodes[0]!;
+    root.raws['templateExpressions'] = undefined;
+    const output = ast.toString(syntax);
+
+    assert.equal(
+      output,
+      `
+      css\`
+        .foo { /*POSTCSS_LIT:0*/color: hotpink; }
+      \`;
+    `
+    );
+  });
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,1 @@
+export const createPlaceholder = (i: number): string => `/*POSTCSS_LIT:${i}*/`;


### PR DESCRIPTION
I have implemented a basic stringifier which rebuilds the original expression text.

In order to retrieve the original text, we have to make use of `raws` on the root node it seems. This could be replaced if some other plugin decides to mutate our placeholder comments, so in those cases we will leave the comments as-is.

~CURRENTLY BLOCKED: This depends on postcss/postcss#1675 being merged and released.~

BLOCKED BY: postcss/postcss#1681