### PR TITLE
fix: support typescript-like decorator syntax

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -20,7 +20,7 @@ export const parse: Parser<Root | Document> = (
   const sourceAsString = source.toString();
   const ast = babelParse(sourceAsString, {
     sourceType: 'unambiguous',
-    plugins: ['typescript'],
+    plugins: ['typescript', ['decorators', {decoratorsBeforeExport: true}]],
     ranges: true
   });
   const extractedStyles = new Set<TaggedTemplateExpression>();


### PR DESCRIPTION
The decorators proposal seems to have settled on decorators _after_ `export`, but most code i've seen in the wild has them _before_.

so ill leave it like this for now until we can specify the choice ourselves in config/babelrc.