### PR TITLE
Base indentation detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postcss-lit",
-  "version": "0.1.3-indent.0",
+  "version": "0.1.3-indent.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postcss-lit",
-      "version": "0.1.3-indent.0",
+      "version": "0.1.3-indent.1",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.16.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postcss-lit",
-  "version": "0.1.2",
+  "version": "0.1.3-indent.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postcss-lit",
-      "version": "0.1.2",
+      "version": "0.1.3-indent.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.16.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-lit",
-  "version": "0.1.2",
+  "version": "0.1.3-indent.0",
   "description": "Lit support for PostCSS and related tooling",
   "main": "lib/main.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-lit",
-  "version": "0.1.3-indent.0",
+  "version": "0.1.3-indent.1",
   "description": "Lit support for PostCSS and related tooling",
   "main": "lib/main.js",
   "files": [

--- a/src/locationCorrection.ts
+++ b/src/locationCorrection.ts
@@ -81,6 +81,12 @@ const correctLocation = (
   return loc;
 };
 
+/**
+ * Corrects the before/after raw strings of a given node
+ * @param {Document|Root|ChildNode} node Node to correct
+ * @param {Map} baseIndentations Map of indentations for each line
+ * @return {void}
+ */
 function correctBeforeAfter(
   node: Document | Root | ChildNode,
   baseIndentations: Map<number, number>

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -66,12 +66,18 @@ export const parse: Parser<Root | Document> = (
       }
     }
 
-    const root = postcssParse(styleText, {
+    const baseIndentation = (node.quasi.loc?.end.column ?? 1) - 1;
+    const deindentedStyleText = styleText.replace(
+      new RegExp(`^[ \\t]{${baseIndentation}}`, 'gm'),
+      ''
+    );
+    const root = postcssParse(deindentedStyleText, {
       ...opts,
       map: false
     }) as Root;
 
     root.raws['templateExpressions'] = expressionStrings;
+    root.raws['baseIndentation'] = baseIndentation;
     root.raws.codeBefore = sourceAsString.slice(currentOffset, startIndex);
     root.parent = doc;
     const walker = locationCorrectionWalker(node);

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -20,7 +20,7 @@ class LitStringifier extends Stringifier {
       const [, expressionIndexString] = node.text.split(':');
       const expressionIndex = Number(expressionIndexString);
       const root = node.root();
-      const expressionStrings = root.raws['templateExpressions'];
+      const expressionStrings = root.raws['litTemplateExpressions'];
 
       if (expressionStrings && !Number.isNaN(expressionIndex)) {
         const expression = expressionStrings[expressionIndex];
@@ -38,8 +38,29 @@ class LitStringifier extends Stringifier {
   /** @inheritdoc */
   public override root(node: Root): void {
     this.builder(node.raws.codeBefore ?? '', node, 'start');
-    super.root(node);
+
+    this.body(node);
+
+    // Here we want to recover any previously removed JS indentation
+    // if possible. Otherwise, we use the `after` string as-is.
+    const after = node.raws['litAfter'] ?? node.raws.after;
+    if (after) {
+      this.builder(after);
+    }
+
     this.builder(node.raws.codeAfter ?? '', node, 'end');
+  }
+
+  /** @inheritdoc */
+  public override raw(
+    node: AnyNode,
+    own: string,
+    detect: string | undefined
+  ): string {
+    if (own === 'before' && node.raws['before'] && node.raws['litBefore']) {
+      return node.raws['litBefore'];
+    }
+    return super.raw(node, own, detect);
   }
 }
 

--- a/src/test/locationCorrection_test.ts
+++ b/src/test/locationCorrection_test.ts
@@ -158,25 +158,6 @@ describe('locationCorrection', () => {
     assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
 
-  it('should correct indentation', () => {
-    const {ast} = createTestAst(`
-      css\`
-        .foo { color: hotpink; }
-      \`;
-    `);
-    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
-    assert.deepEqual(rule.source!.start, {
-      offset: 0,
-      column: 1,
-      line: 1
-    });
-    assert.deepEqual(rule.source!.end, {
-      offset: 0,
-      column: 1,
-      line: 1
-    });
-  });
-
   it('should account for mixed indentation', () => {
     const {source, ast} = createTestAst(`
       css\`

--- a/src/test/locationCorrection_test.ts
+++ b/src/test/locationCorrection_test.ts
@@ -157,4 +157,45 @@ describe('locationCorrection', () => {
     );
     assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
+
+  it('should correct indentation', () => {
+    const {ast} = createTestAst(`
+      css\`
+        .foo { color: hotpink; }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    assert.deepEqual(rule.source!.start, {
+      offset: 0,
+      column: 1,
+      line: 1
+    });
+    assert.deepEqual(rule.source!.end, {
+      offset: 0,
+      column: 1,
+      line: 1
+    });
+  });
+
+  it('should account for mixed indentation', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+  .foo { $\{expr\}color: hotpink; }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const colour = rule.nodes[1] as Declaration;
+    assert.equal(colour.type, 'decl');
+    assert.equal(rule.type, 'rule');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      '.foo { ${expr}color: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      '.foo { ${expr}color: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+  });
 });

--- a/src/test/locationCorrection_test.ts
+++ b/src/test/locationCorrection_test.ts
@@ -29,6 +29,65 @@ describe('locationCorrection', () => {
     assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
 
+  it('should handle multi-line CSS', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          color: hotpink;
+        }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(colour.type, 'decl');
+    assert.equal(rule.type, 'rule');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      `.foo {
+          color: hotpink;
+        }`
+    );
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      `.foo {
+          color: hotpink;
+        }`
+    );
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+  });
+
+  it('should handle multi-line CSS with expressions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          color: hotpink;
+          $\{expr}
+        }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(colour.type, 'decl');
+    assert.equal(rule.type, 'rule');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      `.foo {
+          color: hotpink;
+          $\{expr}
+        }`
+    );
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      `.foo {
+          color: hotpink;
+          $\{expr}
+        }`
+    );
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+  });
+
   it('should handle single line expressions', () => {
     const {source, ast} = createTestAst(`css\`.foo { color: hotpink; }\`;`);
     const rule = (ast.nodes[0] as Root).nodes[0] as Rule;

--- a/src/test/locationCorrection_test.ts
+++ b/src/test/locationCorrection_test.ts
@@ -29,6 +29,24 @@ describe('locationCorrection', () => {
     assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
 
+  it('should handle single line expressions', () => {
+    const {source, ast} = createTestAst(`css\`.foo { color: hotpink; }\`;`);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(colour.type, 'decl');
+    assert.equal(rule.type, 'rule');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      '.foo { color: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      '.foo { color: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+  });
+
   it('should account for single-line expressions', () => {
     const {source, ast} = createTestAst(`
       css\`

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -115,6 +115,33 @@ describe('parse', () => {
     assert.equal(ast.source!.input.css, source);
   });
 
+  it('should parse multi-line stylesheets containing expressions', async () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          color: hotpink;
+          $\{expr}
+        }
+      \`;
+    `);
+    const root = ast.nodes[0] as Root;
+    const rule = root.nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(ast.type, 'document');
+    assert.equal(root.type, 'root');
+    assert.equal(rule.type, 'rule');
+    assert.equal(colour.type, 'decl');
+    assert.equal(root.raws.codeBefore, '\n      css`\n');
+    assert.equal(root.parent, ast);
+    assert.equal(root.raws.codeAfter, '`;\n    ');
+    assert.deepEqual(ast.source!.start, {
+      line: 1,
+      column: 1,
+      offset: 0
+    });
+    assert.equal(ast.source!.input.css, source);
+  });
+
   it('should parse CSS containing an expression', () => {
     const {source, ast} = createTestAst(`
       css\`

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -89,6 +89,32 @@ describe('parse', () => {
     assert.equal(ast.source!.input.css, source);
   });
 
+  it('should parse multi-line stylesheets', async () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          color: hotpink;
+        }
+      \`;
+    `);
+    const root = ast.nodes[0] as Root;
+    const rule = root.nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+    assert.equal(ast.type, 'document');
+    assert.equal(root.type, 'root');
+    assert.equal(rule.type, 'rule');
+    assert.equal(colour.type, 'decl');
+    assert.equal(root.raws.codeBefore, '\n      css`\n');
+    assert.equal(root.parent, ast);
+    assert.equal(root.raws.codeAfter, '`;\n    ');
+    assert.deepEqual(ast.source!.start, {
+      line: 1,
+      column: 1,
+      offset: 0
+    });
+    assert.equal(ast.source!.input.css, source);
+  });
+
   it('should parse CSS containing an expression', () => {
     const {source, ast} = createTestAst(`
       css\`

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -16,7 +16,7 @@ describe('parse', () => {
     assert.equal(root.type, 'root');
     assert.equal(rule.type, 'rule');
     assert.equal(colour.type, 'decl');
-    assert.equal(root.raws.codeBefore, '\n      css`');
+    assert.equal(root.raws.codeBefore, '\n      css`\n');
     assert.equal(root.parent, ast);
     assert.equal(root.raws.codeAfter, '`;\n    ');
     assert.deepEqual(ast.source!.start, {
@@ -73,7 +73,7 @@ describe('parse', () => {
     const root2 = ast.nodes[1] as Root;
 
     assert.equal(root1.type, 'root');
-    assert.equal(root1.raws.codeBefore, '\n      css`');
+    assert.equal(root1.raws.codeBefore, '\n      css`\n');
     assert.equal(root1.raws.codeAfter, undefined);
     assert.equal(root1.parent, ast);
     assert.equal(root2.type, 'root');

--- a/src/test/postcss_test.ts
+++ b/src/test/postcss_test.ts
@@ -25,7 +25,7 @@ describe('postcss', () => {
     assert.equal(root.type, 'root');
     assert.equal(rule.type, 'rule');
     assert.equal(colour.type, 'decl');
-    assert.equal(root.raws.codeBefore, '\n      css`');
+    assert.equal(root.raws.codeBefore, '\n      css`\n');
     assert.equal(root.parent, ast);
     assert.equal(root.raws.codeAfter, '`;\n    ');
     assert.deepEqual(ast.source!.start, {

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -106,7 +106,7 @@ describe('stringify', () => {
     `);
 
     const root = ast.nodes[0]!;
-    root.raws['templateExpressions'] = undefined;
+    root.raws['litTemplateExpressions'] = undefined;
     const output = ast.toString(syntax);
 
     assert.equal(
@@ -139,7 +139,7 @@ describe('stringify', () => {
     `);
 
     const root = ast.nodes[0]!;
-    root.raws['templateExpressions'] = [];
+    root.raws['litTemplateExpressions'] = [];
     const output = ast.toString(syntax);
 
     assert.equal(

--- a/src/test/stylelint_test.ts
+++ b/src/test/stylelint_test.ts
@@ -123,4 +123,26 @@ describe('stylelint', () => {
     `
     );
   });
+
+  it('should be compatible with indentation rule', async () => {
+    const source = `
+      css\`
+        .foo {
+          width: 100px;
+        }
+      \`;
+    `;
+    const result = await stylelint.lint({
+      customSyntax: syntax,
+      code: source,
+      codeFilename: 'foo.js',
+      config: {
+        rules: {
+          indentation: 2
+        }
+      }
+    });
+
+    assert.equal(result.errored, false);
+  });
 });


### PR DESCRIPTION
This detects the base indentation (that of the last backtick of the template) and removes it from the CSS source before parsing it.

We need this so we don't trigger stylelint's indentation rules incorrectly.

Fixes #14