### PR TITLE
Escape backticks in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,35 @@ module.exports = {
 };
 ```
 
+### PostCSS with webpack
+
+If you use webpack to execute postcss, you must ensure the right order of
+loaders, like so:
+
+```ts
+module.exports = {
+  entry: './src/my-element.ts',
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: ['postcss-loader', 'ts-loader'],
+        exclude: /node_modules/
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.ts']
+  },
+  output: {
+    filename: 'bundle.js'
+  }
+};
+```
+
+This is important as postcss will transform your CSS _before_ typescript
+transpiles to JS (which is what you want to happen).
+
 ## Usage with stylelint
 
 In your `.stylelintrc.json` (or other stylelint config file):
@@ -108,3 +137,7 @@ class MyElement extends LitElement {
   }
 }
 ```
+
+### Tailwind with webpack
+
+See the same advice as with postcss standalone, [here](#postcss-with-webpack).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postcss-lit",
-  "version": "0.4.0",
+  "version": "0.4.1-backticks.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postcss-lit",
-      "version": "0.4.0",
+      "version": "0.4.1-backticks.0",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.16.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postcss-lit",
-  "version": "0.4.1-backticks.0",
+  "version": "0.4.1-backticks.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postcss-lit",
-      "version": "0.4.1-backticks.0",
+      "version": "0.4.1-backticks.1",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-lit",
-  "version": "0.4.1-backticks.0",
+  "version": "0.4.1-backticks.1",
   "description": "Lit support for PostCSS and related tooling",
   "main": "lib/main.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-lit",
-  "version": "0.4.0",
+  "version": "0.4.1-backticks.0",
   "description": "Lit support for PostCSS and related tooling",
   "main": "lib/main.js",
   "files": [

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -15,6 +15,7 @@ const placeholderPattern = /^POSTCSS_LIT:\d+$/;
  * into account.
  */
 class LitStringifier extends Stringifier {
+  /** @inheritdoc */
   public constructor(builder: Builder) {
     const wrappedBuilder: Builder = (
       str: string,

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -15,6 +15,26 @@ const placeholderPattern = /^POSTCSS_LIT:\d+$/;
  * into account.
  */
 class LitStringifier extends Stringifier {
+  public constructor(builder: Builder) {
+    const wrappedBuilder: Builder = (
+      str: string,
+      node?: AnyNode,
+      type?: 'start' | 'end'
+    ): void => {
+      // We purposely ignore the root node since the only thing we should
+      // be stringifying here is already JS (before/after raws) so likely
+      // already contains backticks on purpose.
+      //
+      // For everything else, we want to escape backticks.
+      if (node?.type === 'root') {
+        builder(str, node, type);
+      } else {
+        builder(str.replace(/`/g, '\\`'), node, type);
+      }
+    };
+    super(wrappedBuilder);
+  }
+
   /** @inheritdoc */
   public override comment(node: Comment): void {
     if (placeholderPattern.test(node.text)) {

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -1,3 +1,4 @@
+import {Root, Rule, Declaration} from 'postcss';
 import {assert} from 'chai';
 import {createTestAst} from './util.js';
 import syntax = require('../main.js');
@@ -296,5 +297,25 @@ describe('stringify', () => {
     const output = ast.toString(syntax);
 
     assert.equal(output, source);
+  });
+
+  it('should escape backticks', () => {
+    const {ast} = createTestAst(`
+      css\`.foo { color: hotpink; }\`;
+    `);
+
+    const root = ast.nodes[0] as Root;
+    const rule = root.nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
+
+    colour.raws.between = ': /*comment with `backticks`*/';
+
+    const output = ast.toString(syntax);
+    assert.equal(
+      output,
+      `
+      css\`.foo { color: /*comment with \\\`backticks\\\`*/hotpink; }\`;
+    `
+    );
   });
 });


### PR DESCRIPTION
It is possible transforms inside postcss can introduce backticks, so we need to escape them.