### PR TITLE
fix: do not mutate non-css strings

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -26,8 +26,12 @@ class LitStringifier extends Stringifier {
       // be stringifying here is already JS (before/after raws) so likely
       // already contains backticks on purpose.
       //
+      // Similarly, if there is no node, we're probably stringifying
+      // pure JS which never contained any CSS. Or something really weird
+      // we don't want to touch anyway.
+      //
       // For everything else, we want to escape backticks.
-      if (node?.type === 'root') {
+      if (!node || node?.type === 'root') {
         builder(str, node, type);
       } else {
         builder(str.replace(/`/g, '\\`'), node, type);

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -318,4 +318,18 @@ describe('stringify', () => {
     `
     );
   });
+
+  it('should not escape unrelated backticks', () => {
+    const {ast} = createTestAst(`
+      html\`<div></div>\`;
+    `);
+    const output = ast.toString(syntax);
+
+    assert.equal(
+      output,
+      `
+      html\`<div></div>\`;
+    `
+    );
+  });
 });


### PR DESCRIPTION
Basically, if you have a source file with no CSS, like so:

```ts
html`<div></div>`;
```

it appears postcss will stringify it but have no reference `node`. in these cases, i _think_ (or hope) we can safely assume we're not stringifying CSS and to just leave it alone.

this was causing backticks in JS to be escaped before.

cc @abdonrd