### PR TITLE
feat: add stricter expression placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,103 @@ build.
 ### Tailwind with webpack
 
 See the same advice as with postcss standalone, [here](#postcss-with-webpack).
+
+## Disable specific templates
+
+You can use `postcss-lit-disable-next-line` to disable a particular template
+from being processed:
+
+```ts
+// postcss-lit-disable-next-line
+css`some template`;
+```
+
+These templates will be left as-is and won't make their way through postcss.
+
+## Note on expressions/interpolation
+
+Often you may end up with expressions in your templates. For example:
+
+```ts
+css`
+  .foo {
+    color: ${expr};
+  }
+`;
+```
+
+These can be very difficult to support at build-time since we have no useful
+run-time information for what the expression might be.
+
+Due to these difficulties, we officially support _complete_ syntax being
+interpolated, though other cases may still work.
+
+A few **supported** examples:
+
+```ts
+// Entire selector bound in
+css`
+  ${expr} {
+    color: hotpink;
+  }
+`;
+
+// Entire property bound in
+css`
+  .foo {
+    ${expr}: hotpink;
+  }
+`;
+
+// Entire value bound in
+css`
+  .foo {
+    color: ${expr};
+  }
+`;
+
+// Entire statement bound in
+css`
+  .foo {
+    ${expr}
+  }
+`;
+
+// Entire block bound in
+css`
+  .foo {}
+  ${expr}
+`;
+```
+
+And a few **unsupported** examples (though some _may_ work, they are not
+officially supported):
+
+```ts
+// Part of a selector bound in
+css`
+  .foo, ${expr} {
+    color: hotpink;
+  }
+`;
+
+// Part of a value bound in
+css`
+  .foo {
+    color: hot${expr};
+  }
+`;
+
+// Part of a property bound in
+css`
+  .foo {
+    col${expr}: hotpink;
+  }
+`;
+```
+
+In cases we fail to parse, we will raise a warning in the console and skip
+the template (i.e. leave it untouched and won't process it).
+
+You can then use a `// postcss-lit-disable-next-line` comment to silence the
+warning.

--- a/src/test/locationCorrection_test.ts
+++ b/src/test/locationCorrection_test.ts
@@ -150,6 +150,58 @@ describe('locationCorrection', () => {
     assert.equal(getSourceForNodeByRange(source, colour), 'color: ${expr};');
   });
 
+  it('should account for expressions in unusual positions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        h$\{i} {
+          color: hotpink;
+        }
+        .foo {
+          padding: 0px $\{expr\};
+        }
+      \`;
+    `);
+    const root = ast.nodes[0] as Root;
+    const rule0 = root.nodes[0] as Rule;
+    const rule1 = root.nodes[1] as Rule;
+    const padding = rule1.nodes[0] as Declaration;
+    assert.equal(padding.type, 'decl');
+    assert.equal(rule0.type, 'rule');
+    assert.equal(rule1.type, 'rule');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule0),
+      `h$\{i} {
+          color: hotpink;
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByLoc(source, rule1),
+      `.foo {
+          padding: 0px $\{expr\};
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByLoc(source, padding),
+      'padding: 0px ${expr};'
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, rule0),
+      `h$\{i} {
+          color: hotpink;
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, rule1),
+      `.foo {
+          padding: 0px $\{expr\};
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, padding),
+      'padding: 0px ${expr};'
+    );
+  });
+
   it('should account for multiple single-line expressions', () => {
     const {source, ast} = createTestAst(`
       css\`

--- a/src/test/locationCorrection_test.ts
+++ b/src/test/locationCorrection_test.ts
@@ -1,4 +1,4 @@
-import {Root, Rule, Declaration} from 'postcss';
+import {Root, Rule, Declaration, Comment, AtRule} from 'postcss';
 import {assert} from 'chai';
 import {
   createTestAst,
@@ -88,7 +88,7 @@ describe('locationCorrection', () => {
     assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
   });
 
-  it('should handle single line expressions', () => {
+  it('should handle single line css', () => {
     const {source, ast} = createTestAst(`css\`.foo { color: hotpink; }\`;`);
     const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
     const colour = rule.nodes[0] as Declaration;
@@ -109,51 +109,67 @@ describe('locationCorrection', () => {
   it('should account for single-line expressions', () => {
     const {source, ast} = createTestAst(`
       css\`
-        .foo { $\{expr\}color: hotpink; }
+        .foo { $\{expr\}: hotpink; }
       \`;
     `);
     const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
-    const colour = rule.nodes[1] as Declaration;
+    const expr = rule.nodes[0] as Declaration;
+    assert.equal(expr.type, 'decl');
+    assert.equal(rule.type, 'rule');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      '.foo { ${expr}: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByLoc(source, expr), '${expr}: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      '.foo { ${expr}: hotpink; }'
+    );
+    assert.equal(getSourceForNodeByRange(source, expr), '${expr}: hotpink;');
+  });
+
+  it('should account for expressions in value positions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo { color: $\{expr\}; }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const colour = rule.nodes[0] as Declaration;
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
     assert.equal(
       getSourceForNodeByLoc(source, rule),
-      '.foo { ${expr}color: hotpink; }'
+      '.foo { color: ${expr}; }'
     );
-    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByLoc(source, colour), 'color: ${expr};');
     assert.equal(
       getSourceForNodeByRange(source, rule),
-      '.foo { ${expr}color: hotpink; }'
+      '.foo { color: ${expr}; }'
     );
-    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByRange(source, colour), 'color: ${expr};');
   });
 
   it('should account for multiple single-line expressions', () => {
     const {source, ast} = createTestAst(`
       css\`
-        .foo { $\{expr\}color: $\{expr2\}hotpink; }
+        .foo { $\{expr\}: $\{expr2\}; }
       \`;
     `);
     const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
-    const colour = rule.nodes[1] as Declaration;
+    const colour = rule.nodes[0] as Declaration;
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
     assert.equal(
       getSourceForNodeByLoc(source, rule),
-      '.foo { ${expr}color: ${expr2}hotpink; }'
+      '.foo { ${expr}: ${expr2}; }'
     );
-    assert.equal(
-      getSourceForNodeByLoc(source, colour),
-      'color: ${expr2}hotpink;'
-    );
+    assert.equal(getSourceForNodeByLoc(source, colour), '${expr}: ${expr2};');
     assert.equal(
       getSourceForNodeByRange(source, rule),
-      '.foo { ${expr}color: ${expr2}hotpink; }'
+      '.foo { ${expr}: ${expr2}; }'
     );
-    assert.equal(
-      getSourceForNodeByRange(source, colour),
-      'color: ${expr2}hotpink;'
-    );
+    assert.equal(getSourceForNodeByRange(source, colour), '${expr}: ${expr2};');
   });
 
   it('should account for multi-line expressions', () => {
@@ -161,55 +177,201 @@ describe('locationCorrection', () => {
       css\`
         .foo { $\{
           expr
-        \}color: hotpink; }
+        \}: hotpink; }
       \`;
     `);
     const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
-    const colour = rule.nodes[1] as Declaration;
+    const colour = rule.nodes[0] as Declaration;
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
     assert.equal(
       getSourceForNodeByLoc(source, rule),
       `.foo { $\{
           expr
-        }color: hotpink; }`
+        }: hotpink; }`
     );
-    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByLoc(source, colour),
+      `$\{
+          expr
+        }: hotpink;`
+    );
     assert.equal(
       getSourceForNodeByRange(source, rule),
       `.foo { $\{
           expr
-        }color: hotpink; }`
+        }: hotpink; }`
     );
-    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, colour),
+      `$\{
+          expr
+        }: hotpink;`
+    );
   });
 
   it('should account for multiple mixed-size expressions', () => {
     const {source, ast} = createTestAst(`
       css\`
-        .foo { $\{
-          expr
-        \} $\{expr2\}color: hotpink; }
+        .foo {
+          $\{
+            expr
+          \}
+          $\{expr2\}
+        }
       \`;
     `);
     const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
-    const colour = rule.nodes[2] as Declaration;
-    assert.equal(colour.type, 'decl');
+    const expr0 = rule.nodes[0] as Comment;
+    const expr1 = rule.nodes[1] as Comment;
+    assert.equal(expr0.type, 'comment');
+    assert.equal(expr1.type, 'comment');
     assert.equal(rule.type, 'rule');
     assert.equal(
       getSourceForNodeByLoc(source, rule),
-      `.foo { $\{
-          expr
-        } $\{expr2}color: hotpink; }`
+      `.foo {
+          $\{
+            expr
+          }
+          $\{expr2}
+        }`
     );
-    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByLoc(source, expr0),
+      `$\{
+            expr
+          }`
+    );
+    assert.equal(getSourceForNodeByLoc(source, expr1), '${expr2}');
     assert.equal(
       getSourceForNodeByRange(source, rule),
-      `.foo { $\{
-          expr
-        } $\{expr2}color: hotpink; }`
+      `.foo {
+          $\{
+            expr
+          }
+          $\{expr2}
+        }`
     );
-    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+    assert.equal(
+      getSourceForNodeByRange(source, expr0),
+      `$\{
+            expr
+          }`
+    );
+    assert.equal(getSourceForNodeByRange(source, expr1), '${expr2}');
+  });
+
+  it('should account for expressions as properties', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          color: $\{expr\}
+        }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const statement = rule.nodes[0] as Declaration;
+    assert.equal(statement.type, 'decl');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      `.foo {
+          color: $\{expr}
+        }`
+    );
+    assert.equal(getSourceForNodeByLoc(source, statement), `color: $\{expr}`);
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      `.foo {
+          color: $\{expr}
+        }`
+    );
+    assert.equal(getSourceForNodeByRange(source, statement), `color: $\{expr}`);
+  });
+
+  it('should account for expressions as statements', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          $\{expr\}
+        }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const comment = rule.nodes[0] as Comment;
+    assert.equal(comment.type, 'comment');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      `.foo {
+          $\{expr}
+        }`
+    );
+    assert.equal(getSourceForNodeByLoc(source, comment), `$\{expr}`);
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      `.foo {
+          $\{expr}
+        }`
+    );
+    assert.equal(getSourceForNodeByRange(source, comment), `$\{expr}`);
+  });
+
+  it('should account for expressions as values', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          $\{expr\}: hotpink;
+        }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    const statement = rule.nodes[0] as Declaration;
+    assert.equal(statement.type, 'decl');
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      `.foo {
+          $\{expr}: hotpink;
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByLoc(source, statement),
+      `$\{expr}: hotpink;`
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      `.foo {
+          $\{expr}: hotpink;
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, statement),
+      `$\{expr}: hotpink;`
+    );
+  });
+
+  it('should account for expressions as selectors', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          color: hotpink;
+        }
+        $\{expr} {
+          color: hotpink;
+        }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[1] as Rule;
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      `$\{expr} {
+          color: hotpink;
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      `$\{expr} {
+          color: hotpink;
+        }`
+    );
   });
 
   it('should account for code before', () => {
@@ -238,22 +400,77 @@ describe('locationCorrection', () => {
   it('should account for mixed indentation', () => {
     const {source, ast} = createTestAst(`
       css\`
-  .foo { $\{expr\}color: hotpink; }
+  .foo { $\{expr\}: hotpink; }
       \`;
     `);
     const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
-    const colour = rule.nodes[1] as Declaration;
+    const colour = rule.nodes[0] as Declaration;
     assert.equal(colour.type, 'decl');
     assert.equal(rule.type, 'rule');
     assert.equal(
       getSourceForNodeByLoc(source, rule),
-      '.foo { ${expr}color: hotpink; }'
+      '.foo { ${expr}: hotpink; }'
     );
-    assert.equal(getSourceForNodeByLoc(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByLoc(source, colour), '${expr}: hotpink;');
     assert.equal(
       getSourceForNodeByRange(source, rule),
-      '.foo { ${expr}color: hotpink; }'
+      '.foo { ${expr}: hotpink; }'
     );
-    assert.equal(getSourceForNodeByRange(source, colour), 'color: hotpink;');
+    assert.equal(getSourceForNodeByRange(source, colour), '${expr}: hotpink;');
+  });
+
+  it('should account for indentation in at-rule params', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        @foo xyz and (
+          bananas: 808px
+        ) {
+        }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as AtRule;
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      `@foo xyz and (
+          bananas: 808px
+        ) {
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      `@foo xyz and (
+          bananas: 808px
+        ) {
+        }`
+    );
+  });
+
+  it('should account for indentation in declaration values', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          border-radius:
+            4px
+            4xp;
+        }
+      \`;
+    `);
+    const rule = (ast.nodes[0] as Root).nodes[0] as Rule;
+    assert.equal(
+      getSourceForNodeByLoc(source, rule),
+      `.foo {
+          border-radius:
+            4px
+            4xp;
+        }`
+    );
+    assert.equal(
+      getSourceForNodeByRange(source, rule),
+      `.foo {
+          border-radius:
+            4px
+            4xp;
+        }`
+    );
   });
 });

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -1,4 +1,4 @@
-import {Root, Rule, Declaration, Comment} from 'postcss';
+import {Root, Rule, Declaration, Comment, AtRule} from 'postcss';
 import {assert} from 'chai';
 import {createTestAst} from './util.js';
 
@@ -162,18 +162,17 @@ describe('parse', () => {
   it('should parse CSS containing an expression', () => {
     const {source, ast} = createTestAst(`
       css\`
-        .foo { $\{expr}color: hotpink; }
+        .foo { $\{expr}: hotpink; }
       \`;
     `);
     const root = ast.nodes[0] as Root;
     const rule = root.nodes[0] as Rule;
-    const placeholder = rule.nodes[0] as Comment;
-    const colour = rule.nodes[1] as Declaration;
+    const expr = rule.nodes[0] as Declaration;
     assert.equal(ast.type, 'document');
     assert.equal(root.type, 'root');
     assert.equal(rule.type, 'rule');
-    assert.equal(placeholder.type, 'comment');
-    assert.equal(colour.type, 'decl');
+    assert.equal(expr.type, 'decl');
+    assert.equal(expr.prop, '--POSTCSS_LIT_0');
     assert.equal(ast.source!.input.css, source);
   });
 
@@ -203,6 +202,154 @@ describe('parse', () => {
       offset: 0
     });
     assert.equal(ast.source!.input.css, source);
+  });
+
+  it('should parse expression in selector position', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        $\{expr} {
+          color: hotpink;
+        }
+      \`;
+    `);
+    assert.equal(ast.source!.input.css, source);
+    const root = ast.nodes[0] as Root;
+
+    const rule0 = root.nodes[0] as Rule;
+    assert.equal(rule0.type, 'rule');
+    assert.equal(rule0.selector, 'POSTCSS_LIT_0');
+  });
+
+  it('should parse expression in property position', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        foo {
+          $\{expr}: hotpink;
+        }
+      \`;
+    `);
+    assert.equal(ast.source!.input.css, source);
+    const root = ast.nodes[0] as Root;
+
+    const rule0 = root.nodes[0] as Rule;
+    const rule0Statement0 = rule0.nodes[0] as Declaration;
+    assert.equal(rule0Statement0.type, 'decl');
+    assert.equal(rule0Statement0.prop, '--POSTCSS_LIT_0');
+  });
+
+  it('should parse expression in value position', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        foo {
+          color: $\{expr};
+        }
+      \`;
+    `);
+    assert.equal(ast.source!.input.css, source);
+    const root = ast.nodes[0] as Root;
+
+    const rule0 = root.nodes[0] as Rule;
+    const rule0Statement0 = rule0.nodes[0] as Declaration;
+    assert.equal(rule0Statement0.type, 'decl');
+    assert.equal(rule0Statement0.prop, 'color');
+    assert.equal(rule0Statement0.value, 'POSTCSS_LIT_0');
+  });
+
+  it('should parse expression in comment', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        foo {
+          color: hotpink;
+        }
+
+        /* a real comment $\{expr} */
+      \`;
+    `);
+    assert.equal(ast.source!.input.css, source);
+    const root = ast.nodes[0] as Root;
+
+    const comment = root.nodes[1] as Comment;
+    assert.equal(comment.text, 'a real comment POSTCSS_LIT_0');
+  });
+
+  it('should parse expression in block position', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {}
+
+        $\{expr}
+      \`;
+    `);
+    assert.equal(ast.source!.input.css, source);
+    const root = ast.nodes[0] as Root;
+
+    const rule0 = root.nodes[1] as Comment;
+    assert.equal(rule0.type, 'comment');
+    assert.equal(rule0.text, 'POSTCSS_LIT_0');
+  });
+
+  it('should parse expression in statement position', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        .foo {
+          $\{expr}
+        }
+
+        .bar {
+          color: hotpink;
+          $\{expr}
+        }
+      \`;
+    `);
+    assert.equal(ast.source!.input.css, source);
+    const root = ast.nodes[0] as Root;
+
+    const rule0 = root.nodes[0] as Rule;
+    const comment0 = rule0.nodes[0] as Comment;
+    assert.equal(comment0.type, 'comment');
+    assert.equal(comment0.text, 'POSTCSS_LIT_0');
+
+    const rule1 = root.nodes[1] as Rule;
+    const comment1 = rule1.nodes[1] as Comment;
+    assert.equal(comment1.type, 'comment');
+    assert.equal(comment1.text, 'POSTCSS_LIT_1');
+  });
+
+  it('should parse expression in statement position of at-rule', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        @foo {
+          .foo {
+            $\{expr}
+          }
+        }
+      \`;
+    `);
+    assert.equal(ast.source!.input.css, source);
+    const root = ast.nodes[0] as Root;
+
+    const atRule = root.nodes[0] as AtRule;
+    const rule = atRule.nodes[0] as Rule;
+    const comment = rule.nodes[0] as Comment;
+    assert.equal(comment.type, 'comment');
+    assert.equal(comment.text, 'POSTCSS_LIT_0');
+  });
+
+  it('should parse expression in block position of at-rule', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        @foo {
+          $\{expr}
+        }
+      \`;
+    `);
+    assert.equal(ast.source!.input.css, source);
+    const root = ast.nodes[0] as Root;
+
+    const atRule = root.nodes[0] as AtRule;
+    const comment = atRule.nodes[0] as Comment;
+    assert.equal(comment.type, 'comment');
+    assert.equal(comment.text, 'POSTCSS_LIT_0');
   });
 
   it('should ignore disabled lines', () => {

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -371,4 +371,14 @@ describe('parse', () => {
     `);
     assert.equal(ast.nodes.length, 0);
   });
+
+  it('should ignore invalid templates', () => {
+    const {ast} = createTestAst(`
+      css\`
+        .foo { /* absolute nonsense */
+      \`;
+    `);
+
+    assert.equal(ast.nodes.length, 0);
+  });
 });

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -42,6 +42,23 @@ describe('stringify', () => {
     assert.equal(output, source);
   });
 
+  it('should stringify expressions with unusual positions', () => {
+    const {source, ast} = createTestAst(`
+      css\`
+        h$\{i} {
+          color: hotpink;
+        }
+        .foo {
+          padding: 0px $\{expr\};
+        }
+      \`;
+    `);
+
+    const output = ast.toString(syntax);
+
+    assert.equal(output, source);
+  });
+
   it('should stringify multiple expressions', () => {
     const {source, ast} = createTestAst(`
       css\`

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -114,7 +114,7 @@ describe('stringify', () => {
       output,
       `
       css\`
-        .foo { /*POSTCSS_LIT:0*/color: hotpink; }
+        .foo { /*POSTCSS_LIT_0*/color: hotpink; }
       \`;
     `
     );
@@ -147,7 +147,7 @@ describe('stringify', () => {
       output,
       `
       css\`
-        .foo { /*POSTCSS_LIT:0*/color: hotpink; }
+        .foo { /*POSTCSS_LIT_0*/color: hotpink; }
       \`;
     `
     );

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,6 @@
 import {NodePath} from '@babel/traverse';
 import {TaggedTemplateExpression, Comment} from '@babel/types';
 
-export const createPlaceholder = (i: number): string => `/*POSTCSS_LIT:${i}*/`;
-
 /**
  * Determines if a given comment is a postcss-lit-disable comment
  * @param {Comment} node Node to test
@@ -34,4 +32,160 @@ export function hasDisableComment(
   }
 
   return false;
+}
+
+export type Position =
+  | 'block'
+  | 'statement'
+  | 'default'
+  | 'selector'
+  | 'property'
+  | 'comment';
+
+const whitespacePattern = /\s/;
+
+interface PlaceholderConfig {
+  create(key: number): string;
+  regex: RegExp;
+}
+
+export const defaultPlaceholder: PlaceholderConfig = {
+  create(key) {
+    return `POSTCSS_LIT_${key}`;
+  },
+  regex: /POSTCSS_LIT_(\d+)/
+};
+
+export const placeholderMapping: Partial<Record<Position, PlaceholderConfig>> =
+  {
+    block: {
+      create(key) {
+        return `/*POSTCSS_LIT_${key}*/`;
+      },
+      regex: /\/\*POSTCSS_LIT_(\d+)\*\//
+    },
+    statement: {
+      create(key) {
+        return `/*POSTCSS_LIT_${key}*/`;
+      },
+      regex: /\/\*POSTCSS_LIT_(\d+)\*\//
+    },
+    property: {
+      create(key) {
+        return `--POSTCSS_LIT_${key}`;
+      },
+      regex: /--POSTCSS_LIT_(\d+)/
+    }
+  };
+
+/**
+ * Computes the placeholder for an expression
+ * @param {number} i Expression index
+ * @param {string=} prefix Source prefix so far
+ * @param {string=} suffix Source suffix
+ * @return {string}
+ */
+export function createPlaceholder(
+  i: number,
+  prefix?: string,
+  suffix?: string
+): string {
+  if (!prefix) {
+    return defaultPlaceholder.create(i);
+  }
+
+  const position = computePossiblePosition(prefix, suffix);
+
+  return (placeholderMapping[position] ?? defaultPlaceholder).create(i);
+}
+
+/**
+ * Finds the first non-space character of a string
+ * @param {string} str String to search
+ * @return {string|null}
+ */
+function findFirstNonSpaceChar(str: string): string | null {
+  for (let i = 0; i < str.length; i++) {
+    const chr = str[i];
+
+    if (chr === undefined) {
+      return null;
+    }
+
+    if (whitespacePattern.test(chr)) {
+      continue;
+    }
+
+    return chr;
+  }
+
+  return null;
+}
+
+/**
+ * Computes whether the current position may be block-level or not,
+ * such that we can choose a more appropriate placeholder.
+ * @param {string} prefix Source prefix to scan
+ * @param {string=} suffix Source suffix to scan
+ * @return {boolean}
+ */
+function computePossiblePosition(prefix: string, suffix?: string): Position {
+  let possiblyInComment = false;
+  let possiblePosition: Position = 'default';
+  for (let i = prefix.length; i > 0; i--) {
+    const chr = prefix[i];
+    if (possiblyInComment) {
+      if (chr === '/' && prefix[i + 1] === '*') {
+        possiblyInComment = false;
+      }
+      continue;
+    } else {
+      if (chr === '/' && prefix[i + 1] === '*') {
+        possiblePosition = 'comment';
+        break;
+      }
+    }
+    if (chr === '*' && prefix[i + 1] === '/') {
+      possiblyInComment = true;
+      continue;
+    }
+    if (chr === ';') {
+      possiblePosition = 'statement';
+      break;
+    }
+    if (chr === ':') {
+      possiblePosition = 'default';
+      break;
+    }
+    if (chr === '}') {
+      possiblePosition = 'block';
+      break;
+    }
+    if (chr === '{') {
+      possiblePosition = 'statement';
+      break;
+    }
+  }
+
+  if (suffix) {
+    const nextChr = findFirstNonSpaceChar(suffix);
+
+    switch (possiblePosition) {
+      case 'block': {
+        if (nextChr === '{') {
+          possiblePosition = 'selector';
+        }
+        break;
+      }
+
+      case 'statement': {
+        if (nextChr === ':') {
+          possiblePosition = 'property';
+        }
+        break;
+      }
+    }
+  }
+
+  return possiblePosition;
 }


### PR DESCRIPTION
Fixes #6.

Briefly, the problem we've had all along is that there's no one placeholder which will produce valid syntax for all positions an expression may be interpolated into.

This can't ever really be solved perfectly as we have no idea until run-time what the actual interpolated value will be, and what position it is in.

Until now, we use a CSS comment as a placeholder, but this means something like the following will not work:

```js
css`
  .foo {
    color: ${expr};
  }
`;
```

The reason is, this will become:

```css
.foo {
  color: /*PLACEHOLDER*/;
}
```

Which, from an AST point of view, is the same as having a value-less declaration. This can cause all sorts of problems.

In this rework, we instead try to guess what kind of position we're in based on looking ahead/behind then choosing the right placeholder (syntax) for that position.

**This means we no longer support _all_ binding positions**. We didn't anyway, since errors were thrown in many cases, but now we actually have a known constraint around this.

As long as you're interpolating complete pieces of syntax in, everything should be fine. For example, these should all be fine:

```js
css`
  ${expr} {
    color: hotpink;
  }

  .foo {
    color: ${expr};
  }

  .foo {
    ${expr}: hotpink;
  }

  .foo {
    ${expr}
  }
`;
```

While these are all near impossible for us to understand within the linter so are no longer allowed:

```js
css`
  .foo, ${expr} {
    color: hotpink;
  }

  .foo {
    prop: ${expr}-abc;
  }
`;
```

These are all partially interpolated pieces of syntax: part of a selector, part of a value, etc. Which will no longer work (if it ever did).

cc @stramel @timbomckay @Garbee @kutnickclose in case any of you are still interested/curious about this, have any feedback, etc.

ill publish a prerelease so people can try it out soon