### PR TITLE
feat: add disable comments

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -3,7 +3,7 @@ import postcssParse from 'postcss/lib/parse';
 import {parse as babelParse} from '@babel/parser';
 import {default as traverse, NodePath} from '@babel/traverse';
 import {TaggedTemplateExpression} from '@babel/types';
-import {createPlaceholder} from './util.js';
+import {createPlaceholder, hasDisableComment} from './util.js';
 import {locationCorrectionWalker} from './locationCorrection.js';
 
 /**
@@ -33,7 +33,11 @@ export const parse: Parser<Root | Document> = (
     TaggedTemplateExpression: (
       path: NodePath<TaggedTemplateExpression>
     ): void => {
-      if (path.node.tag.type === 'Identifier' && path.node.tag.name === 'css') {
+      if (
+        path.node.tag.type === 'Identifier' &&
+        path.node.tag.name === 'css' &&
+        !hasDisableComment(path)
+      ) {
         extractedStyles.add(path.node);
       }
     }

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -204,4 +204,24 @@ describe('parse', () => {
     });
     assert.equal(ast.source!.input.css, source);
   });
+
+  it('should ignore disabled lines', () => {
+    const {ast} = createTestAst(`
+      // postcss-lit-disable-next-line
+      css\`
+        .foo { color: hotpink; }
+      \`;
+    `);
+    assert.equal(ast.nodes.length, 0);
+  });
+
+  it('should ignore deeply disabled lines', () => {
+    const {ast} = createTestAst(`
+      // postcss-lit-disable-next-line
+      someFunction([a, b, css\`
+        .foo { color: hotpink; }
+      \`]);
+    `);
+    assert.equal(ast.nodes.length, 0);
+  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,1 +1,37 @@
+import {NodePath} from '@babel/traverse';
+import {TaggedTemplateExpression, Comment} from '@babel/types';
+
 export const createPlaceholder = (i: number): string => `/*POSTCSS_LIT:${i}*/`;
+
+/**
+ * Determines if a given comment is a postcss-lit-disable comment
+ * @param {Comment} node Node to test
+ * @return {boolean}
+ */
+export function isDisableComment(node: Comment): boolean {
+  return (
+    node.type === 'CommentLine' &&
+    node.value.includes('postcss-lit-disable-next-line')
+  );
+}
+/**
+ * Determines if a node has a leading postcss-lit-disable comment
+ * @param {NodePath<TaggedTemplateExpression>} path NodePath to test
+ * @return {boolean}
+ */
+export function hasDisableComment(
+  path: NodePath<TaggedTemplateExpression>
+): boolean {
+  const statement = path.getStatementParent();
+
+  if (statement && statement.node.leadingComments) {
+    const comment =
+      statement.node.leadingComments[statement.node.leadingComments.length - 1];
+
+    if (comment !== undefined && isDisableComment(comment)) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
This'll allow people to disable individual css stylesheets with a line comment:

```ts
// postcss-lit-disable-next-line
css`whatever`;
```

which should mean people having trouble with #35 can at least disable their complex interpolated sheets individually.