### PR TITLE
fix: unescape backslashes on the way into the parser

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -122,7 +122,9 @@ export const parse: Parser<Root | Document> = (
       }
     }
 
-    const deindentedStyleText = deindentedLines.join('\n');
+    const deindentedStyleText = deindentedLines
+      .join('\n')
+      .replace(/\\\\/g, '\\');
     let root: Root;
 
     try {

--- a/src/test/stringify_test.ts
+++ b/src/test/stringify_test.ts
@@ -364,7 +364,7 @@ describe('stringify', () => {
     );
   });
 
-  it('should escape backslashes', () => {
+  it('should escape backslashes from mutated ast', () => {
     const {ast} = createTestAst(`
       css\`.foo { color: hotpink; }\`;
     `);
@@ -379,6 +379,20 @@ describe('stringify', () => {
       output,
       `
       css\`.foo\\\\:bar { color: hotpink; }\`;
+    `
+    );
+  });
+
+  it('should escape backslashes from input', () => {
+    const {ast} = createTestAst(`
+      css\`.foo { content: "\\\\eee"; }\`;
+    `);
+
+    const output = ast.toString(syntax);
+    assert.equal(
+      output,
+      `
+      css\`.foo { content: "\\\\eee"; }\`;
     `
     );
   });


### PR DESCRIPTION
We already account for escape sequences added to the AST _later on_ (i.e. something like stylelint, postcss, etc has mutated it).

However, we do not unescape sequences on the way into the parser.

For example:

```ts
css`
  .foo {
    content: "\\abc";
  }
`;
```

This is already escaped, once for JS, once for the resulting CSS.

When we parse this, we extract the CSS _and keep the double-escape_. This of course means the resulting CSS file internally has one too many escapes.

Fixes #51
To account for this, we now unescape CSS on the way in (i.e. replace double escapes with single).