### PR TITLE
Improve warning output

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -134,7 +134,7 @@ export const parse: Parser<Root | Document> = (
       }) as Root;
     } catch (err) {
       if (err instanceof CssSyntaxError) {
-        const line = node.loc ? ` (Line ${node.loc.start.line})` : '';
+        const line = node.loc ? ` (${opts.from}:${node.loc.start.line})` : opts.from;
 
         console.warn(
           '[postcss-lit]',

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -134,7 +134,7 @@ export const parse: Parser<Root | Document> = (
       }) as Root;
     } catch (err) {
       if (err instanceof CssSyntaxError) {
-        const line = node.loc ? ` (${opts.from}:${node.loc.start.line})` : opts.from;
+        const line = node.loc ? ` (${opts?.from ?? 'unknown'}:${node.loc.start.line})` : opts?.from;
 
         console.warn(
           '[postcss-lit]',


### PR DESCRIPTION
Improves warning output when the plugin could not interpret the code sufficiently to include the file containing the issue.

Before:
> [postcss-lit] Skipping template (Line [line]) as it included either invalid syntax or complex expressions the plugin could not interpret. Consider using a "// postcss-lit-disable-next-line" comment to disable this message

After:
> [postcss-lit] Skipping template ([path]:[line]) as it included either invalid syntax or complex expressions the plugin could not interpret. Consider using a "// postcss-lit-disable-next-line" comment to disable this message