### PR TITLE
Allow disable comment to be the directly above the statement

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -134,7 +134,9 @@ export const parse: Parser<Root | Document> = (
       }) as Root;
     } catch (err) {
       if (err instanceof CssSyntaxError) {
-        const line = node.loc ? ` (${opts?.from ?? 'unknown'}:${node.loc.start.line})` : opts?.from;
+        const line = node.loc
+          ? ` (${opts?.from ?? 'unknown'}:${node.loc.start.line})`
+          : opts?.from;
 
         console.warn(
           '[postcss-lit]',

--- a/src/test/parse_test.ts
+++ b/src/test/parse_test.ts
@@ -363,6 +363,47 @@ describe('parse', () => {
     assert.equal(ast.nodes.length, 0);
   });
 
+  it('should ignore a child node', () => {
+    const {ast} = createTestAst(`
+      class MyClass {
+        // postcss-lit-disable-next-line
+        static style = css\`
+          .foo { color: hotpink; }
+        \`;
+      }
+    `);
+
+    assert.equal(ast.nodes.length, 0);
+  });
+
+  it('should ignore a child node from an array', () => {
+    const {ast} = createTestAst(`
+      class MyClass {
+        static style = [
+          // postcss-lit-disable-next-line
+          css\`
+            .foo { color: hotpink; }
+          \`,
+        ];
+      }
+    `);
+
+    assert.equal(ast.nodes.length, 0);
+  });
+
+  it('should ignore everything inside a disabled parent node', () => {
+    const {ast} = createTestAst(`
+      // postcss-lit-disable-next-line
+      class MyClass {
+        static style = css\`
+          .foo { color: hotpink; }
+        \`;
+      }
+    `);
+
+    assert.equal(ast.nodes.length, 0);
+  });
+
   it('should ignore deeply disabled lines', () => {
     const {ast} = createTestAst(`
       // postcss-lit-disable-next-line

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,9 +21,10 @@ export function hasDisableComment(
   path: NodePath<TaggedTemplateExpression>
 ): boolean {
   // The comment could be above the parent node or directly above the statement
-  const leadingComments = path.getStatementParent()?.node.leadingComments ?? path.node.leadingComments;
+  const leadingComments = path.getStatementParent()?.node.leadingComments ??
+    path.node.leadingComments;
   // There could be multiple preceding the comments
-  return leadingComments?.some(comment => isDisableComment(comment)) ?? false;
+  return leadingComments?.some((comment) => isDisableComment(comment)) ?? false;
 }
 
 export type Position =

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,7 +21,7 @@ export function hasDisableComment(
   path: NodePath<TaggedTemplateExpression>
 ): boolean {
   // The comment could be directly above the statement or above the parent node
-  const leadingComments = path.node.leadingComments ?? path.getStatementParent()?.node.leadingComments;
+  const leadingComments = path.getStatementParent()?.node.leadingComments ?? path.node.leadingComments;
   // There could be multiple preceding the comments
   return leadingComments?.some(comment => isDisableComment(comment)) ?? false;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ import {TaggedTemplateExpression, Comment} from '@babel/types';
  */
 export function isDisableComment(node: Comment): boolean {
   return (
-    node && node.type === 'CommentLine' &&
+    node.type === 'CommentLine' &&
     node.value.includes('postcss-lit-disable-next-line')
   );
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ import {TaggedTemplateExpression, Comment} from '@babel/types';
  */
 export function isDisableComment(node: Comment): boolean {
   return (
-    node.type === 'CommentLine' &&
+    node && node.type === 'CommentLine' &&
     node.value.includes('postcss-lit-disable-next-line')
   );
 }
@@ -20,18 +20,10 @@ export function isDisableComment(node: Comment): boolean {
 export function hasDisableComment(
   path: NodePath<TaggedTemplateExpression>
 ): boolean {
-  const statement = path.getStatementParent();
-
-  if (statement && statement.node.leadingComments) {
-    const comment =
-      statement.node.leadingComments[statement.node.leadingComments.length - 1];
-
-    if (comment !== undefined && isDisableComment(comment)) {
-      return true;
-    }
-  }
-
-  return false;
+  // The comment could be directly above the statement or above the parent node
+  const leadingComments = path.node.leadingComments ?? path.getStatementParent()?.node.leadingComments;
+  // There could be multiple preceding the comments
+  return leadingComments?.some(comment => isDisableComment(comment)) ?? false;
 }
 
 export type Position =

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,7 +20,7 @@ export function isDisableComment(node: Comment): boolean {
 export function hasDisableComment(
   path: NodePath<TaggedTemplateExpression>
 ): boolean {
-  // The comment could be directly above the statement or above the parent node
+  // The comment could be above the parent node or directly above the statement
   const leadingComments = path.getStatementParent()?.node.leadingComments ?? path.node.leadingComments;
   // There could be multiple preceding the comments
   return leadingComments?.some(comment => isDisableComment(comment)) ?? false;

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,7 @@ export function hasDisableComment(
 ): boolean {
   // The comment could be above the parent node or directly above the statement
   const leadingComments = path.getStatementParent()?.node.leadingComments ??
+    path.parent.leadingComments ??
     path.node.leadingComments;
   // There could be multiple preceding the comments
   return leadingComments?.some((comment) => isDisableComment(comment)) ?? false;

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,9 +21,12 @@ export function hasDisableComment(
   path: NodePath<TaggedTemplateExpression>
 ): boolean {
   // The comment could be directly above the node or above any of its parents
-  return !!path.find((p) =>
-    // There could be multiple preceding the comments
-    !!p.node.leadingComments?.some((comment) => isDisableComment(comment))
+  return (
+    path.find(
+      (p) =>
+        // There could be multiple preceding the comments
+        p.node.leadingComments?.some(isDisableComment) === true
+    ) !== null
   );
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,12 +20,11 @@ export function isDisableComment(node: Comment): boolean {
 export function hasDisableComment(
   path: NodePath<TaggedTemplateExpression>
 ): boolean {
-  // The comment could be above the parent node or directly above the statement
-  const leadingComments = path.getStatementParent()?.node.leadingComments ??
-    path.parent.leadingComments ??
-    path.node.leadingComments;
-  // There could be multiple preceding the comments
-  return leadingComments?.some((comment) => isDisableComment(comment)) ?? false;
+  // The comment could be directly above the node or above any of its parents
+  return !!path.find((p) =>
+    // There could be multiple preceding the comments
+    !!p.node.leadingComments?.some((comment) => isDisableComment(comment))
+  );
 }
 
 export type Position =


### PR DESCRIPTION
The comment line to disable the postcss-lit plugin (`postcss-lit-disable-next-line`) doesn't necessarily need to be on the parent statement, especially with static class fields being more and more mainstream: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static

The following snippet breaks stylelint with postcss-lit:

```javascript
const MY_CONST = 600;

export class MyClass extends LitElement {
  static styles = css`
    @media (width >= ${MY_CONST}px) {
      ...
    }
  `;
}
```

Errors:
- Unexpected invalid media query        media-query-no-invalid
   "(width >= POSTCSS_LIT_0px)"
- Unexpected unknown media feature      media-feature-name-no-unknown
   name "POSTCSS_LIT_0px"

To disable the plugin, I'd now have to disable it for the entire class because `styles` is a static class field and therefore the parent statement is the `MyClass` class:
```javascript
const MY_CONST = 600;

// postcss-lit-disable-next-line
export class MyClass extends LitElement {
  static styles = css`
    @media (width >= ${MY_CONST}px) {
      ...
    }
  `;
}
```

Because my classes contain more CSS than just this media statement, I'd like to be able to not disable this plugin for the entire class nor do I want to replace my static class field back to a getter. This PR allows disable comments to be placed directly above the statement, but the previous behaviour of looking at the parent comments is taking precedence so that it should not be a breaking change. This now works:

```javascript
const MY_CONST = 600;

export class MyClass extends LitElement {
  static styles = [
    // postcss-lit-disable-next-line
    css`
      @media (width >= ${MY_CONST}px) {
        ...
      }
    `,
    css`
      .my-class-i-want-to-stylelint {
        ...
      }
    `,
  ];
}
```

I also made it so the disable comment doesn't necessarily need to be the last comment before the statement. It can be one of the comments which is required if I also want to disable for example eslint for the same line, e.g.:

```javascript
// postcss-lit-disable-next-line
// eslint-disable-next-line
css`
  @media (width >= ${MY_CONST}px) {
    ...
  }
`
```

Let me know what you think, I'm open for suggestions!

---

EDIT:
Future work: maybe think about also supporting the following syntax:

```javascript
css`
  /* postcss-lit-disable-next-line */
  .foo { color: hotpink; }
`;
```

As far as I can see the CSS tagged template expression is not parsed by Babel though, so it might require using another library for that.