### PR TITLE
fix: Not all expressions are mapped back

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -49,7 +49,7 @@ export const defaultPlaceholder: PlaceholderConfig = {
   create(key) {
     return `POSTCSS_LIT_${key}`;
   },
-  regex: /POSTCSS_LIT_(\d+)/
+  regex: /POSTCSS_LIT_(\d+)/g
 };
 
 export const placeholderMapping: Partial<Record<Position, PlaceholderConfig>> =
@@ -58,19 +58,19 @@ export const placeholderMapping: Partial<Record<Position, PlaceholderConfig>> =
       create(key) {
         return `/* POSTCSS_LIT_${key} */`;
       },
-      regex: /\/\* POSTCSS_LIT_(\d+)\*\//
+      regex: /\/\* POSTCSS_LIT_(\d+)\*\//g
     },
     statement: {
       create(key) {
         return `/* POSTCSS_LIT_${key} */`;
       },
-      regex: /\/\* POSTCSS_LIT_(\d+) \*\//
+      regex: /\/\* POSTCSS_LIT_(\d+) \*\//g
     },
     property: {
       create(key) {
         return `--POSTCSS_LIT_${key}`;
       },
-      regex: /--POSTCSS_LIT_(\d+)/
+      regex: /--POSTCSS_LIT_(\d+)/g
     }
   };
 


### PR DESCRIPTION
I had the problem that some expressions were replaced by placeholders:

```css
transition:
  width ${TransitionDuration}ms ease-in-out,
  opacity ${TransitionDuration}ms ease-in-out,
  transform ${TransitionDuration}ms ease-in-out;
```

```css
transition:
  width ${TransitionDuration}ms ease-in-out,
  opacity POSTCSS_LIT_1ms ease-in-out,
  transform POSTCSS_LIT_2ms ease-in-out;
```

My initial guess was that only the first occurrence was remapped each time during stringification. Therefore, I added the `global` flag to the placeholder regex so that all occurrences are attempted to be remapped during replacement.

https://github.com/43081j/postcss-lit/blob/45252cf704cd45eecd463c47fd7b262d6b191aba/src/stringify.ts#L45-L51

As it turned out, adding the `global` flag indeed solved the problem.